### PR TITLE
reactComponentExpect fails silently

### DIFF
--- a/src/test/reactComponentExpect.js
+++ b/src/test/reactComponentExpect.js
@@ -28,6 +28,7 @@ function reactComponentExpect(instance) {
   }
 
   expect(instance).not.toBeNull();
+  expect(instance).not.toBeUndefined();
 
   invariant(
     ReactTestUtils.isCompositeComponent(instance),


### PR DESCRIPTION
`reactComponentExpect` fails silently when passed an undefined  value. It calls `ReactTestUtils.isCompositeComponent` with the undefined value, in which a `render` property is accessed, throwing a prop on undefined not found error which isn't surfaced to jest.

```
TypeError: Cannot read property 'render' of undefined
        at Object.ReactTestUtils.isCompositeComponent (./react/test/ReactTestUtils.js:127:23)
        at new reactComponentExpect (./react/test/reactComponentExpect.js:46:20)
        at reactComponentExpect (./react/test/reactComponentExpect.js:40:12)
```

Expecting the passed-in instance to not be undefined surfaces this issue in the test runner.
